### PR TITLE
Add preset fine-tuning selections

### DIFF
--- a/frontend/src/FineTuningDemo.tsx
+++ b/frontend/src/FineTuningDemo.tsx
@@ -17,6 +17,8 @@ import {
 import type { SimpleMessage } from "@/components/chat/ChatMessage";
 import { testFineTunedDM, type FineTuningRequest } from "@/services/api-mock";
 import { ChatMessage } from "@/components/chat/ChatMessage";
+import { FineTuningPresetSelector } from "@/components/aicomponent/FineTuningPresetSelector";
+import { type FineTuningPreset } from "@/presets";
 
 export function FineTuningDemo() {
   const [personality] = useState("classic");
@@ -39,6 +41,7 @@ export function FineTuningDemo() {
   const [assistantMessages, setAssistantMessages] = useState<SimpleMessage[]>([]);
   const [assistantInput, setAssistantInput] = useState("");
   const [training, setTraining] = useState(false);
+  const [preset, setPreset] = useState<FineTuningPreset | null>(null);
 
 
   const buildRequest = (): FineTuningRequest => ({
@@ -68,6 +71,14 @@ export function FineTuningDemo() {
     if (e.target.files && e.target.files[0]) {
       setDatasetFile(e.target.files[0]);
     }
+  };
+
+  const applyPreset = (p: FineTuningPreset) => {
+    setPreset(p);
+    setEpochs(p.epochs);
+    setTrainingSteps(p.trainingSteps);
+    setLearningRate(p.learningRate);
+    setQuantization(p.quantization);
   };
 
   const startTraining = async () => {
@@ -133,6 +144,10 @@ export function FineTuningDemo() {
                     <p className="text-xs text-gray-400">{datasetFile.name}</p>
                   )}
                 </div>
+                <FineTuningPresetSelector value={preset?.id ?? null} onValueChange={applyPreset} />
+                {preset && (
+                  <p className="text-xs text-gray-400">{preset.description}</p>
+                )}
                 <div className="space-y-2">
                   <label className="block text-sm font-medium text-muted-foreground mb-1">Training Epochs</label>
                   <Input

--- a/frontend/src/components/aicomponent/FineTuningPresetSelector.tsx
+++ b/frontend/src/components/aicomponent/FineTuningPresetSelector.tsx
@@ -1,0 +1,33 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { fineTuningPresets, type FineTuningPreset } from "@/presets";
+
+interface Props {
+  value: string | null;
+  onValueChange: (preset: FineTuningPreset) => void;
+}
+
+export function FineTuningPresetSelector({ value, onValueChange }: Props) {
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-medium text-muted-foreground">Preset</label>
+      <Select
+        value={value ?? ""}
+        onValueChange={(id) => {
+          const p = fineTuningPresets.find((pr) => pr.id === id);
+          if (p) onValueChange(p);
+        }}
+      >
+        <SelectTrigger className="w-56 bg-card border border-border">
+          <SelectValue placeholder="Choose a preset" />
+        </SelectTrigger>
+        <SelectContent>
+          {fineTuningPresets.map((p) => (
+            <SelectItem key={p.id} value={p.id}>
+              {p.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/presets.ts
+++ b/frontend/src/presets.ts
@@ -1,0 +1,39 @@
+export interface FineTuningPreset {
+  id: string;
+  name: string;
+  description: string;
+  epochs: number;
+  trainingSteps: number;
+  learningRate: number;
+  quantization: "none" | "int8" | "int4";
+}
+
+export const fineTuningPresets: FineTuningPreset[] = [
+  {
+    id: "fast-summarization",
+    name: "Fast Summarization",
+    description: "Optimized for quick summarization of short text snippets.",
+    epochs: 2,
+    trainingSteps: 400,
+    learningRate: 0.0001,
+    quantization: "int8",
+  },
+  {
+    id: "creative-writing",
+    name: "Creative Writing",
+    description: "Encourages more imaginative and narrative-driven output.",
+    epochs: 4,
+    trainingSteps: 1200,
+    learningRate: 0.00005,
+    quantization: "none",
+  },
+  {
+    id: "technical-qa",
+    name: "Technical Q&A",
+    description: "Focuses on accurate technical question answering.",
+    epochs: 3,
+    trainingSteps: 1000,
+    learningRate: 0.00005,
+    quantization: "none",
+  },
+];


### PR DESCRIPTION
## Summary
- add `FineTuningPreset` definitions
- add selector component for choosing a preset
- integrate preset selector into the demo page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684125f6978c8323bc326c8fd29a63f9