### PR TITLE
Integrate HuggingFace and OpenAI

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+MONGODB_URI=mongodb+srv://cstannahill10:<db_password>@c0.ti97tni.mongodb.net/?retryWrites=true&w=majority&appName=c0
+MONGODB_DB=codetune
+OPENAI_API_KEY=<your_openai_api_key>
+HUGGINGFACE_TOKEN=<your_huggingface_token>

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,11 +12,13 @@ This backend is built with [FastAPI](https://fastapi.tiangolo.com/) and uses Mon
 
 ## Development
 
-Create a `.env` file or set the following environment variables:
+Create a `.env` file (see `.env.example`) or set the following environment variables:
 
 ```
-MONGODB_URI=mongodb://localhost:27017
+MONGODB_URI=mongodb+srv://cstannahill10:<db_password>@c0.ti97tni.mongodb.net/?retryWrites=true&w=majority&appName=c0
 MONGODB_DB=codetune
+OPENAI_API_KEY=<your_openai_api_key>
+HUGGINGFACE_TOKEN=<your_huggingface_token>
 ```
 
 Install dependencies and start the server:

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
-from .endpoints import tuning, analytics
+from .endpoints import tuning, analytics, assistant, models
 
 api_router = APIRouter()
 api_router.include_router(tuning.router)
 api_router.include_router(analytics.router)
+api_router.include_router(assistant.router)
+api_router.include_router(models.router)

--- a/backend/app/api/v1/endpoints/assistant.py
+++ b/backend/app/api/v1/endpoints/assistant.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from ...core.config import settings
+from ....services.assistant_service import AssistantService
+
+router = APIRouter(prefix="/assistant", tags=["assistant"])
+
+class ChatRequest(BaseModel):
+    messages: list[dict]
+    model: str | None = None
+
+async def get_service():
+    return AssistantService()
+
+@router.post("/chat")
+async def chat(req: ChatRequest, service: AssistantService = Depends(get_service)):
+    model = req.model or "gpt-3.5-turbo"
+    response = await service.chat(req.messages, model=model)
+    return {"response": response}

--- a/backend/app/api/v1/endpoints/models.py
+++ b/backend/app/api/v1/endpoints/models.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from fastapi.concurrency import run_in_threadpool
+from huggingface_hub import list_models
+from ....core.config import settings
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+@router.get("/")
+async def get_models():
+    models = await run_in_threadpool(
+        list_models, filter="text-generation", limit=20, token=settings.huggingface_token
+    )
+    return [{"id": m.modelId, "downloads": m.downloads} for m in models]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,8 @@ class Settings(BaseSettings):
     app_name: str = "CodeTune Backend"
     mongodb_uri: str = Field(..., env="MONGODB_URI")
     mongodb_db: str = Field(default="codetune", env="MONGODB_DB")
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    huggingface_token: str | None = Field(default=None, env="HUGGINGFACE_TOKEN")
     class Config:
         case_sensitive = True
 

--- a/backend/app/services/assistant_service.py
+++ b/backend/app/services/assistant_service.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+import openai
+from ..core.config import settings
+
+class AssistantService:
+    def __init__(self):
+        self.client = openai.AsyncOpenAI(api_key=settings.openai_api_key)
+
+    async def chat(self, messages: List[Dict], model: str = "gpt-3.5-turbo") -> str:
+        response = await self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+        )
+        return response.choices[0].message.content

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn[standard]
 motor
 pydantic
+openai
+huggingface_hub

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,7 @@
 # React + TypeScript + Vite
 
+Create a `.env` file based on `.env.example` to configure the backend API URL.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/frontend/src/components/aicomponent/AIModelSelector.tsx
+++ b/frontend/src/components/aicomponent/AIModelSelector.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { fetchModels } from "@/services/api";
 
 interface Props {
   value: string;
@@ -6,16 +8,27 @@ interface Props {
 }
 
 export function AIModelSelector({ value, onValueChange }: Props) {
+  const [models, setModels] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetchModels()
+      .then((ms) => setModels(ms.map((m) => m.id)))
+      .catch(() => setModels([]));
+  }, []);
+
   return (
     <div className="space-y-1">
       <label className="text-sm font-medium text-muted-foreground">Base Model</label>
       <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger className="w-40 bg-card border border-border">
-          <SelectValue />
+        <SelectTrigger className="w-48 bg-card border border-border">
+          <SelectValue placeholder="Select model" />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="gpt-4">GPT-4</SelectItem>
           <SelectItem value="gpt-3.5-turbo">GPT-3.5 Turbo</SelectItem>
+          {models.map((m) => (
+            <SelectItem key={m} value={m}>{m}</SelectItem>
+          ))}
         </SelectContent>
       </Select>
     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,22 @@
+const API_URL = import.meta.env.VITE_API_URL ?? '';
+
+export interface HFModel { id: string; downloads: number }
+
+export async function fetchModels(): Promise<HFModel[]> {
+  const res = await fetch(`${API_URL}/api/v1/models/`);
+  if (!res.ok) throw new Error('Failed to load models');
+  return res.json();
+}
+
+export interface ChatMessage { role: 'user' | 'assistant' | 'system'; content: string }
+
+export async function assistantChat(messages: ChatMessage[]): Promise<string> {
+  const res = await fetch(`${API_URL}/api/v1/assistant/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+  if (!res.ok) throw new Error('Assistant request failed');
+  const data = await res.json();
+  return data.response as string;
+}


### PR DESCRIPTION
## Summary
- add placeholders for DB and API credentials
- use huggingface_hub and openai on the backend
- expose /models and /assistant/chat endpoints
- fetch available models in the UI
- hook assistant chat into OpenAI backend
- document env vars

## Testing
- `python3 -m pip install -r backend/requirements.txt`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6841350e2e3083238e04459aed15c8b3