### PR TITLE
Add Ollama integration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,30 @@ This backend is built with [FastAPI](https://fastapi.tiangolo.com/) and uses Mon
 - `app/services` - business logic and database interactions
 - `app/schemas` - Pydantic models used for requests and responses
 
+### Ollama Integration
+
+Ollama is used for running local models. Fine-tune a base model using external
+tools (e.g. Hugging Face Transformers, PEFT or Unsloth), then convert the
+resulting checkpoint to the GGUF format with `llama.cpp`. Create a `Modelfile`
+that references the GGUF file:
+
+```text
+FROM ./path/to/your-model.gguf
+TEMPLATE """{{ if .System }}\n{{ .System }}\n{{ end }}\n{{ .Prompt }}"""
+```
+
+Load the model into Ollama with:
+
+```bash
+ollama create mymodel -f Modelfile
+```
+
+The API exposes the following new endpoints:
+
+- `GET /api/v1/ollama/models` - list locally available models
+- `POST /api/v1/ollama/pull` - download a model
+- `POST /api/v1/ollama/chat` - generate chat completions using a model
+
 ### New Endpoints
 
 - `POST /api/v1/user-models/` - save parameters and results as a model

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,12 @@
 from fastapi import APIRouter
-from .endpoints import tuning, analytics, assistant, models, user_models
+from .endpoints import (
+    tuning,
+    analytics,
+    assistant,
+    models,
+    user_models,
+    ollama,
+)
 
 api_router = APIRouter()
 api_router.include_router(tuning.router)
@@ -7,3 +14,4 @@ api_router.include_router(analytics.router)
 api_router.include_router(assistant.router)
 api_router.include_router(models.router)
 api_router.include_router(user_models.router)
+api_router.include_router(ollama.router)

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -3,6 +3,7 @@ from .analytics import router as analytics_router
 from .assistant import router as assistant_router
 from .models import router as models_router
 from .user_models import router as user_models_router
+from .ollama import router as ollama_router
 
 __all__ = [
     "tuning_router",
@@ -10,4 +11,5 @@ __all__ = [
     "assistant_router",
     "models_router",
     "user_models_router",
+    "ollama_router",
 ]

--- a/backend/app/api/v1/endpoints/ollama.py
+++ b/backend/app/api/v1/endpoints/ollama.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from ....services import OllamaService
+
+router = APIRouter(prefix="/ollama", tags=["ollama"])
+
+
+def get_service():
+    return OllamaService()
+
+
+@router.get("/models")
+async def list_models(service: OllamaService = Depends(get_service)):
+    return await service.list_models()
+
+
+class ChatRequest(BaseModel):
+    messages: list[dict]
+    model: str
+
+
+@router.post("/chat")
+async def chat(req: ChatRequest, service: OllamaService = Depends(get_service)):
+    response = await service.chat(req.messages, req.model)
+    return {"response": response}
+
+
+class PullRequest(BaseModel):
+    model: str
+
+
+@router.post("/pull")
+async def pull(req: PullRequest, service: OllamaService = Depends(get_service)):
+    await service.pull_model(req.model)
+    return {"status": "ok"}

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,5 @@
 from .tuning_service import TuningService
 from .model_service import ModelService
+from .ollama_service import OllamaService
 
-__all__ = ["TuningService", "ModelService"]
+__all__ = ["TuningService", "ModelService", "OllamaService"]

--- a/backend/app/services/ollama_service.py
+++ b/backend/app/services/ollama_service.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+import ollama
+
+class OllamaService:
+    def __init__(self):
+        self.client = ollama.AsyncClient()
+
+    async def list_models(self) -> List[str]:
+        res = await self.client.list()
+        return [m.model for m in res.models]
+
+    async def pull_model(self, model: str) -> None:
+        await self.client.pull(model)
+
+    async def chat(self, messages: List[Dict], model: str) -> str:
+        res = await self.client.chat(model=model, messages=messages)
+        return res.message.content

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ motor
 pydantic
 openai
 huggingface_hub
+ollama

--- a/frontend/src/FineTuningDemo.tsx
+++ b/frontend/src/FineTuningDemo.tsx
@@ -41,7 +41,7 @@ import {
   saveModel,
   type SavedModel,
 } from "@/services/api";
-import { ChatMessage } from "@/components/chat/ChatMessage";
+import { ChatMessage as ChatMessageComponent } from "@/components/chat/ChatMessage";
 import { FineTuningPresetSelector } from "@/components/aicomponent/FineTuningPresetSelector";
 import { type FineTuningPreset } from "@/presets";
 
@@ -502,7 +502,7 @@ export function FineTuningDemo() {
           </CardHeader>
           <CardContent className="flex-1 overflow-auto space-y-2">
             {assistantMessages.map((m) => (
-              <ChatMessage key={m.id} message={m} />
+              <ChatMessageComponent key={m.id} message={m} />
             ))}
           </CardContent>
           <div className="p-2 border-t border-border flex gap-2 bg-black/50">

--- a/frontend/src/components/aicomponent/AIModelSelector.tsx
+++ b/frontend/src/components/aicomponent/AIModelSelector.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { fetchModels } from "@/services/api";
+import { fetchModels, fetchOllamaModels } from "@/services/api";
 
 interface Props {
   value: string;
@@ -11,8 +11,8 @@ export function AIModelSelector({ value, onValueChange }: Props) {
   const [models, setModels] = useState<string[]>([]);
 
   useEffect(() => {
-    fetchModels()
-      .then((ms) => setModels(ms.map((m) => m.id)))
+    Promise.all([fetchModels(), fetchOllamaModels()])
+      .then(([hf, local]) => setModels([...hf.map((m) => m.id), ...local]))
       .catch(() => setModels([]));
   }, []);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -56,3 +56,34 @@ export async function importModel(modelId: string) {
   if (!res.ok) throw new Error('Import failed');
   return res.json();
 }
+
+// Ollama endpoints
+export async function fetchOllamaModels(): Promise<string[]> {
+  const res = await fetch(`${API_URL}/api/v1/ollama/models`);
+  if (!res.ok) throw new Error('Failed to list models');
+  return res.json();
+}
+
+export async function pullOllamaModel(model: string) {
+  const res = await fetch(`${API_URL}/api/v1/ollama/pull`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model }),
+  });
+  if (!res.ok) throw new Error('Pull failed');
+  return res.json();
+}
+
+export async function ollamaChat(
+  messages: ChatMessage[],
+  model: string,
+): Promise<string> {
+  const res = await fetch(`${API_URL}/api/v1/ollama/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages, model }),
+  });
+  if (!res.ok) throw new Error('Ollama chat failed');
+  const data = await res.json();
+  return data.response as string;
+}


### PR DESCRIPTION
## Summary
- integrate local Ollama models
- expose `/ollama` API endpoints
- fetch Ollama models in the frontend and update model selector
- support Ollama chat and model pulling in the API service
- document Ollama workflow and endpoints

## Testing
- `python -m py_compile backend/app/**/*.py`
- `npx tsc -p tsconfig.app.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68417ea2719883239a4629f71408ed25