### PR TITLE
Add pipeline for HF to Ollama

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,21 @@ Load the model into Ollama with:
 ollama create mymodel -f Modelfile
 ```
 
+### Fine-tuning workflow
+
+The typical workflow to fine-tune and serve a model locally is:
+
+1. **Download a base model** from HuggingFace using `POST /api/v1/models/pull`.
+2. **Run a tuning task** with `POST /api/v1/tuning/` providing dataset and
+   training parameters.
+3. After training, convert the resulting checkpoint to **GGUF** and create a
+   minimal `Modelfile` referencing it.
+4. **Create the Ollama model** by calling `POST /api/v1/ollama/create` with the
+   model name and path to the Modelfile (or GGUF file).
+
+Once created, the model can be listed with `/api/v1/ollama/models` and used for
+chat completions via `/api/v1/ollama/chat`.
+
 The API exposes the following new endpoints:
 
 - `GET /api/v1/ollama/models` - list locally available models

--- a/backend/app/api/v1/endpoints/ollama.py
+++ b/backend/app/api/v1/endpoints/ollama.py
@@ -33,3 +33,15 @@ class PullRequest(BaseModel):
 async def pull(req: PullRequest, service: OllamaService = Depends(get_service)):
     await service.pull_model(req.model)
     return {"status": "ok"}
+
+
+class CreateRequest(BaseModel):
+    name: str
+    modelfile: str
+    gguf_path: str | None = None
+
+
+@router.post("/create")
+async def create(req: CreateRequest, service: OllamaService = Depends(get_service)):
+    await service.create_model(req.name, req.modelfile, req.gguf_path)
+    return {"status": "ok"}

--- a/backend/app/services/ollama_service.py
+++ b/backend/app/services/ollama_service.py
@@ -17,6 +17,24 @@ class OllamaService:
     async def pull_model(self, model: str) -> None:
         await self.client.pull(model)
 
+    async def create_model(self, name: str, modelfile: str, gguf_path: str | None = None) -> None:
+        """Create a local Ollama model from a Modelfile or GGUF checkpoint.
+
+        If ``gguf_path`` is provided a minimal Modelfile will be written that
+        references the GGUF file. Otherwise ``modelfile`` must point to an
+        existing Modelfile on disk.
+        """
+        file_path = modelfile
+        if gguf_path:
+            file_path = modelfile
+            template = (
+                f"FROM {gguf_path}\n" +
+                "TEMPLATE \"""{{ if .System }}\n{{ .System }}\n{{ end }}\n{{ .Prompt }}\""""
+            )
+            with open(file_path, "w") as f:
+                f.write(template)
+        await self.client.create(model=name, from_=file_path)
+
     async def chat(self, messages: List[Dict], model: str) -> str:
         logger.debug(
             "Starting Ollama chat",

--- a/backend/scripts/hf_ollama_pipeline.py
+++ b/backend/scripts/hf_ollama_pipeline.py
@@ -1,0 +1,53 @@
+import argparse
+import asyncio
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(SCRIPT_DIR, ".."))
+
+# minimal env vars so importing the app package succeeds
+os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017")
+os.environ.setdefault("OPENAI_API_KEY", "dummy")
+
+import importlib.util
+
+HF_PATH = os.path.join(SCRIPT_DIR, "..", "app", "services", "hf_model_io.py")
+OLLAMA_PATH = os.path.join(SCRIPT_DIR, "..", "app", "services", "ollama_service.py")
+
+spec = importlib.util.spec_from_file_location("hf_model_io", HF_PATH)
+hf_model_io = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hf_model_io)  # type: ignore
+HFModelIO = hf_model_io.HFModelIO
+
+spec = importlib.util.spec_from_file_location("ollama_service", OLLAMA_PATH)
+ollama_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ollama_mod)  # type: ignore
+OllamaService = ollama_mod.OllamaService
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Download a model from HuggingFace and load it into Ollama")
+    p.add_argument("repo_id", help="HuggingFace repository id")
+    p.add_argument("hf_token", help="HuggingFace token")
+    p.add_argument("hf_user", help="HuggingFace username or org")
+    p.add_argument("name", help="Name for the Ollama model")
+    p.add_argument("gguf_path", help="Path to the GGUF file produced after fine-tuning")
+    p.add_argument("modelfile", help="Path to write the temporary Modelfile")
+    p.add_argument("--local-dir", default="./models", help="Directory to download the model")
+    return p.parse_args()
+
+
+async def main():
+    args = parse_args()
+    hf = HFModelIO(args.hf_token, args.hf_user)
+    local_path = hf.download_model(args.repo_id, os.path.join(args.local_dir, args.name))
+    print(f"Model downloaded to {local_path}")
+
+    service = OllamaService()
+    await service.create_model(args.name, args.modelfile, args.gguf_path)
+    print(f"Created Ollama model {args.name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add ability to create Ollama models from a Modelfile or GGUF
- expose `POST /ollama/create` endpoint
- document full fine‑tuning workflow
- include helper script `hf_ollama_pipeline.py`

## Testing
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_e_6850a9d3a7648323a1381dd985d76b37