### PR TITLE
Add full fine-tune pipeline

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -55,6 +55,20 @@ The API exposes the following new endpoints:
 - `POST /api/v1/user-models/import/{model_id}` - start a new tuning job from a saved model
 - `GET /api/v1/user-models/` - list saved models
 
+### Command line pipeline
+
+A helper script `scripts/hf_ollama_pipeline.py` automates the full workflow. It
+downloads a base model, optionally fine-tunes it on a text dataset, converts the
+result to GGUF, and loads it into Ollama:
+
+```bash
+python scripts/hf_ollama_pipeline.py <repo_id> <hf_token> <hf_user> <name> Modelfile \
+  --dataset train.txt --epochs 1 --push
+```
+
+The script requires the `llama.cpp` `convert.py` utility to be available (use
+`--converter-script` to specify its path).
+
 ## Development
 
 Create a `.env` file (see `.env.example`) or set the following environment variables:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,6 @@ huggingface_hub
 sqlalchemy
 ollama
 rich
+transformers
+datasets
+peft

--- a/backend/scripts/hf_ollama_pipeline.py
+++ b/backend/scripts/hf_ollama_pipeline.py
@@ -2,6 +2,17 @@ import argparse
 import asyncio
 import os
 import sys
+import subprocess
+from typing import Optional
+
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
 
 SCRIPT_DIR = os.path.dirname(__file__)
 sys.path.append(os.path.join(SCRIPT_DIR, ".."))
@@ -27,25 +38,116 @@ OllamaService = ollama_mod.OllamaService
 
 
 def parse_args():
-    p = argparse.ArgumentParser(description="Download a model from HuggingFace and load it into Ollama")
+    p = argparse.ArgumentParser(
+        description=(
+            "Download a model, optionally fine-tune it and load the result into Ollama"
+        )
+    )
     p.add_argument("repo_id", help="HuggingFace repository id")
     p.add_argument("hf_token", help="HuggingFace token")
     p.add_argument("hf_user", help="HuggingFace username or org")
     p.add_argument("name", help="Name for the Ollama model")
-    p.add_argument("gguf_path", help="Path to the GGUF file produced after fine-tuning")
-    p.add_argument("modelfile", help="Path to write the temporary Modelfile")
-    p.add_argument("--local-dir", default="./models", help="Directory to download the model")
+    p.add_argument(
+        "modelfile", help="Path to write the Modelfile referencing the GGUF file"
+    )
+    p.add_argument(
+        "--local-dir", default="./models", help="Directory to download the model"
+    )
+    p.add_argument(
+        "--dataset",
+        help="Optional dataset path for fine-tuning (plain text with one sample per line)",
+    )
+    p.add_argument(
+        "--output-dir",
+        default="./finetuned",
+        help="Directory to save the fine-tuned model",
+    )
+    p.add_argument(
+        "--epochs",
+        type=int,
+        default=1,
+        help="Number of training epochs for fine-tuning",
+    )
+    p.add_argument(
+        "--gguf-path",
+        default=None,
+        help="Where to write the converted GGUF model (default: <output-dir>/model.gguf)",
+    )
+    p.add_argument(
+        "--push",
+        action="store_true",
+        help="Push the fine-tuned model back to HuggingFace",
+    )
+    p.add_argument(
+        "--converter-script",
+        default="convert.py",
+        help="Path to llama.cpp convert.py script",
+    )
     return p.parse_args()
+
+
+def train_model(model_dir: str, dataset_path: str, output_dir: str, epochs: int) -> None:
+    """Fine-tune a causal LM on a simple text dataset."""
+    dataset = load_dataset("text", data_files=dataset_path)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    model = AutoModelForCausalLM.from_pretrained(model_dir)
+
+    def tokenize(batch):
+        return tokenizer(batch["text"], truncation=True)
+
+    tokenized = dataset["train"].map(tokenize, batched=True, remove_columns=["text"])
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    args = TrainingArguments(
+        output_dir=output_dir,
+        per_device_train_batch_size=1,
+        num_train_epochs=epochs,
+        logging_steps=10,
+        save_strategy="no",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=tokenized,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+    os.makedirs(output_dir, exist_ok=True)
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+
+def convert_to_gguf(model_dir: str, gguf_path: str, script: str) -> None:
+    """Run llama.cpp convert.py to produce a GGUF file."""
+    cmd = ["python", script, model_dir, gguf_path]
+    subprocess.run(cmd, check=True)
 
 
 async def main():
     args = parse_args()
     hf = HFModelIO(args.hf_token, args.hf_user)
-    local_path = hf.download_model(args.repo_id, os.path.join(args.local_dir, args.name))
-    print(f"Model downloaded to {local_path}")
+    model_dir = hf.download_model(
+        args.repo_id, os.path.join(args.local_dir, args.name)
+    )
+    print(f"Model downloaded to {model_dir}")
+
+    output_dir = args.output_dir
+    if args.dataset:
+        train_model(model_dir, args.dataset, output_dir, args.epochs)
+        model_dir = output_dir
+        print(f"Fine-tuned model saved to {output_dir}")
+
+        if args.push:
+            repo_id = hf.push_model(output_dir, args.name)
+            print(f"Pushed fine-tuned model to {repo_id}")
+
+    gguf_path = args.gguf_path or os.path.join(output_dir, "model.gguf")
+    convert_to_gguf(model_dir, gguf_path, args.converter_script)
 
     service = OllamaService()
-    await service.create_model(args.name, args.modelfile, args.gguf_path)
+    await service.create_model(args.name, args.modelfile, gguf_path)
     print(f"Created Ollama model {args.name}")
 
 


### PR DESCRIPTION
## Summary
- extend `hf_ollama_pipeline.py` to download, fine‑tune, convert, and create an Ollama model
- add `transformers`, `datasets`, and `peft` dependencies
- document command line pipeline in backend README

## Testing
- `python -m py_compile backend/scripts/hf_ollama_pipeline.py`
- `find backend -name '*.py' | xargs python -m py_compile`
- `pip install -r backend/requirements.txt` *(fails: Operation cancelled by user while downloading torch)*

------
https://chatgpt.com/codex/tasks/task_e_6850af9c5c40832386a90e113e3dcdf3