### PR TITLE
Enhance tuning workflow and model management

### DIFF
--- a/backend/app/api/v1/endpoints/user_models.py
+++ b/backend/app/api/v1/endpoints/user_models.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Body
 from bson import ObjectId
 import logging
 
@@ -70,3 +70,15 @@ async def delete_model(
     if not deleted:
         raise HTTPException(status_code=404, detail="Model not found")
     return {"status": "ok"}
+
+
+@router.post("/{model_id}/rename", response_model=SavedModel)
+async def rename_model(
+    model_id: PyObjectId,
+    name: str = Body(..., embed=True),
+    service: ModelService = Depends(get_model_service),
+):
+    updated = await service.rename_model(ObjectId(model_id), name)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Model not found")
+    return updated

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo import ReturnDocument
 import os
 import json
 
@@ -67,3 +68,12 @@ class ModelService:
     async def delete_model(self, model_id: ObjectId) -> bool:
         res = await self.collection.delete_one({"_id": model_id})
         return res.deleted_count == 1
+
+    async def rename_model(self, model_id: ObjectId, name: str) -> SavedModel | None:
+        """Update the name of a saved model and return the updated document."""
+        doc = await self.collection.find_one_and_update(
+            {"_id": model_id},
+            {"$set": {"name": name, "updated_at": datetime.utcnow()}},
+            return_document=ReturnDocument.AFTER,
+        )
+        return SavedModel(**doc) if doc else None

--- a/frontend/src/FineTuningDemo.tsx
+++ b/frontend/src/FineTuningDemo.tsx
@@ -108,6 +108,7 @@ export function FineTuningDemo() {
   const [modelName, setModelName] = useState<string>("No Name");
   const [editingModelName, setEditingModelName] = useState(false);
   const [modelNameEdit, setModelNameEdit] = useState<string | null>(null);
+  const [pushToHf, setPushToHf] = useState(false);
 
   useEffect(() => {
     fetchSavedModels()
@@ -172,6 +173,9 @@ const handleDatasetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const task = await createTuning({
       dataset_id: datasetId,
       parameters: {
+        repo_id: trainingModel,
+        name: modelName,
+        push: pushToHf,
         epochs,
         trainingSteps,
         learningRate,
@@ -202,6 +206,7 @@ const handleDatasetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (prog.result && "loss" in prog.result) {
           setQualityLoss(prog.result.loss as number);
         }
+        setAnalysis(prog.status);
         if (prog.status === "completed" || prog.status === "failed") {
           if (intervalRef.current) clearInterval(intervalRef.current);
           setTraining(false);
@@ -421,6 +426,17 @@ const handleDatasetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
                     <Progress value={uploadProgress} className="h-2" />
                   )}
                 </div>
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Model Name
+                  </label>
+                  <Input
+                    value={modelName}
+                    onChange={(e) => setModelName(e.target.value)}
+                    placeholder="Name for new model"
+                    className="w-64 bg-card border border-border text-primary"
+                  />
+                </div>
                 {savedModels.length > 0 && (
                   <div className="space-y-1">
                     <label className="block text-sm font-medium text-muted-foreground">
@@ -528,6 +544,18 @@ const handleDatasetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
                     smaller but less precise.
                   </p>
                 </div>
+                <div className="flex items-center space-x-2">
+                  <input
+                    id="pushhf"
+                    type="checkbox"
+                    className="accent-purple-500"
+                    checked={pushToHf}
+                    onChange={(e) => setPushToHf(e.target.checked)}
+                  />
+                  <label htmlFor="pushhf" className="text-sm text-muted-foreground">
+                    Push to HuggingFace after training
+                  </label>
+                </div>
                 <Button
                   onClick={startTraining}
                   disabled={training || !datasetId || uploading}
@@ -578,8 +606,8 @@ const handleDatasetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
                 )}
                 {analysis && (
                   <div className="text-sm text-gray-300">
-                    {analysis}{" "}
-                    {qualityLoss !== null && `(Quality loss: ${qualityLoss}%)`}
+                    {analysis.replace(/_/g, " ")}
+                    {qualityLoss !== null && ` (loss: ${qualityLoss})`}
                   </div>
                 )}
                 {!training &&


### PR DESCRIPTION
## Summary
- add API endpoint to rename saved models
- support model rename in model service
- allow pushing saved models to HuggingFace from dashboard
- extend fine‑tuning UI to specify model name, push-to-HF option and show status
- send repo info when creating tuning tasks

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6851386365b483239c2a84c47f3860fb